### PR TITLE
fix: use consitent vite.config.js extension in book

### DIFF
--- a/book/online-book/src/ja/00-introduction/040-setup-project.md
+++ b/book/online-book/src/ja/00-introduction/040-setup-project.md
@@ -198,7 +198,7 @@ pwd # ~/examples/playground
 touch vite.config.js
 ```
 
-vite.config.ts の内容
+vite.config.js の内容
 
 ```ts
 import path from 'node:path'


### PR DESCRIPTION
I found a typo in 040 of Japanese.

I fixed it considering the English version as correct

![CleanShot 2024-11-13 at 11 46 40@2x](https://github.com/user-attachments/assets/e69a733c-7cb6-42ba-be1b-d92fddb29f51)

![CleanShot 2024-11-13 at 11 46 20@2x](https://github.com/user-attachments/assets/340a78cd-13f8-478b-8b34-955ad5d197eb)
