### PR TITLE
docs: Add "ES2020" to compilerOptions.lib in tsconfig.json

### DIFF
--- a/book/online-book/src/ja/00-introduction/040-setup-project.md
+++ b/book/online-book/src/ja/00-introduction/040-setup-project.md
@@ -118,7 +118,7 @@ tsconfig.json の内容
   "compilerOptions": {
     "target": "ES2020",
     "module": "ES2020",
-    "lib": ["DOM"],
+    "lib": ["DOM", "ES2020"],
     "strict": true,
     "paths": {
       "chibivue": ["./packages"]


### PR DESCRIPTION
While following the steps in the guide, I was faced with an error as shown in the screenshot. it appears that the contents of tsconfig.json need to be updated, so I am submitting this PR.
<img width="818" alt="スクリーンショット 2024-12-09 14 17 50" src="https://github.com/user-attachments/assets/e0cf3d74-bcec-4921-a3db-ae01444b9978">
