### PR TITLE
docs: rename chibi-vue to chibivue in debug documentation

### DIFF
--- a/book/online-book/src/bonus/debug-vuejs-core.md
+++ b/book/online-book/src/bonus/debug-vuejs-core.md
@@ -60,7 +60,7 @@ Once cloned, run the script to create the project.
 At this time, you should be asked for the **absolute path** of the local vuejs/core source code, so please enter it.
 
 ```bash
-cd chibi-vue
+cd chibivue
 ni
 nr setup:vue
 

--- a/book/online-book/src/ja/bonus/debug-vuejs-core.md
+++ b/book/online-book/src/ja/bonus/debug-vuejs-core.md
@@ -60,7 +60,7 @@ clone できたら，プロジェクトを作成するスクリプトを実行�
 この際，ローカルにある vuejs/core のソースコードの**絶対パス**を求められるはずなので，入力してください．
 
 ```bash
-cd chibi-vue
+cd chibivue
 ni
 nr setup:vue
 

--- a/book/online-book/src/zh-cn/bonus/debug-vuejs-core.md
+++ b/book/online-book/src/zh-cn/bonus/debug-vuejs-core.md
@@ -60,7 +60,7 @@ git clone https://github.com/chibivue-land/chibivue.git
 此时，您应该被要求输入本地 vuejs/core 源代码的**绝对路径**，所以请输入它．
 
 ```bash
-cd chibi-vue
+cd chibivue
 ni
 nr setup:vue
 

--- a/book/online-book/src/zh-tw/bonus/debug-vuejs-core.md
+++ b/book/online-book/src/zh-tw/bonus/debug-vuejs-core.md
@@ -60,7 +60,7 @@ git clone https://github.com/chibivue-land/chibivue.git
 此時，您應該被要求輸入本地 vuejs/core 原始碼的**絕對路徑**，所以請輸入它．
 
 ```bash
-cd chibi-vue
+cd chibivue
 ni
 nr setup:vue
 


### PR DESCRIPTION
### 📚 Description

Fixed an old directory name in the debug documentation
The git clone command clones into chibivue, but the next step incorrectly said `cd chibi-vue.`
Updated all language versions (EN, JA, ZH-CN, ZH-TW).