### PR TITLE
Fix homepage language switching

### DIFF
--- a/book/online-book/.vitepress/config/shared.ts
+++ b/book/online-book/.vitepress/config/shared.ts
@@ -12,7 +12,7 @@ export const sharedConfig = defineConfig({
   title: "The chibivue Book",
   appearance: "dark",
   description: 'Writing Vue.js: Step by Step, from just one line of "Hello, World".',
-  lang: "ja",
+  lang: "en",
   srcDir: "src",
   srcExclude: ["__wip"],
   markdown: {

--- a/book/online-book/.vitepress/theme/components/CustomHome.vue
+++ b/book/online-book/.vitepress/theme/components/CustomHome.vue
@@ -1,9 +1,20 @@
 <script setup lang="ts">
-import { useData } from 'vitepress'
+import { useData, useRoute } from 'vitepress'
+import { computed } from 'vue'
 import HeroSection from './HeroSection.vue'
 import FeaturesSection from './FeaturesSection.vue'
 
 const { lang } = useData()
+const route = useRoute()
+
+// 現在の言語を取得
+const currentLang = computed(() => {
+  const path = route.path
+  if (path.startsWith('/zh-cn')) return 'zh-cn'
+  if (path.startsWith('/zh-tw')) return 'zh-tw'
+  if (path.startsWith('/ja')) return 'ja'
+  return 'en'
+})
 
 const heroContent: Record<
   string,
@@ -22,8 +33,8 @@ const heroContent: Record<
   ja: {
     tagline:
       "Writing Vue.js: Step by Step, from just one line of 'Hello, World'.",
-    startButton: 'Start Learning',
-    vueButton: 'Vue.js Official',
+    startButton: 'はじめる',
+    vueButton: 'Vue.js 公式',
   },
   'zh-cn': {
     tagline: "编写 Vue.js：从一行 'Hello, World' 开始，循序渐进。",
@@ -147,13 +158,14 @@ const featuresContent: Record<
   ],
 }
 
-const currentHero = heroContent[lang.value] || heroContent.en
-const currentFeatures = featuresContent[lang.value] || featuresContent.en
+const currentHero = computed(() => heroContent[currentLang.value] || heroContent.en)
+const currentFeatures = computed(() => featuresContent[currentLang.value] || featuresContent.en)
 
-const startLink =
-  lang.value === 'en'
+const startLink = computed(() =>
+  currentLang.value === 'en'
     ? '/00-introduction/010-about'
-    : `/${lang.value}/00-introduction/010-about`
+    : `/${currentLang.value}/00-introduction/010-about`
+)
 </script>
 
 <template>


### PR DESCRIPTION
 What's the problem?                                                                                                                                                                                             
                                                                                                                                                                                                                  
  The homepage wasn't responding to language changes. When I switch languages, the navigation updates fine (like "Home" → "首页"), but the hero tagline and features stay in English.                             
                                                                                                                                                                                                                  
  After digging into it, found two issues:                                                                                                                                                                        
                                                                                                                                                                                                                  
  1. Mismatched language codes - The CustomHome component checks lang.value which returns "zh-CN" (uppercase) from VitePress config, but the content object uses "zh-cn" (lowercase) as keys. So it never finds a 
  match and falls back to English.                                                                                                                                                                                
  2. Missing Japanese translations - The ja section in heroContent is consistent with English.
                                                                                                                                                                                                                  
  What changed?                                                                                                                                                                                                   
                                                                                                                                                                                                                  
  - Switched from using lang.value to extracting language from the route path instead. More reliable since we control the routes.                                                                                 
  - Added proper Japanese translations for the hero buttons                                                                                                                                                       
  - Made everything reactive with computed() so it updates immediately when switching languages                                                                                                                   
  - Also fixed a stale default lang setting in shared.ts (was "ja", should be "en" to match root locale)                                                                                                          
                                                                                                                                                                                                                  
  Testing:                                                                                                                                                                                                        
                                                                                                                                                                                                                  
  Now switching between languages works smoothly. English, 简体中文, 繁體中文, and 日本語 all display correctly.                                                                                                  
                                                                                                                                                                                                                  
  Before:                                                                                                                                                                                                         
  https://github.com/chibivue-land/chibivue/issues/624 
      
  After:       

  日本語:        
  <img width="700" alt="图片" src="https://github.com/user-attachments/assets/0f51b2e7-1bb4-49c7-8ba9-91d87f0a6343" />                                                                                                                                                                                                        
                                                                                                                                                                                                                  
 繁體中文:                                                                                                                                                                                                        
  <img width="700" alt="图片" src="https://github.com/user-attachments/assets/c94d0d9b-db6a-41b0-aff1-a8069f4cfda9" />
  简体中文:                                                                                                                                                                                                       
   <img width="700" alt="图片" src="https://github.com/user-attachments/assets/bc352cc9-2450-47e7-88f3-aa535642823a" />
                                                                                                                                                                                                 

  Files changed:                                                                                                                                                                                                  
  - .vitepress/config/shared.ts - Updated default lang                                                                                                                                                            
  - .vitepress/theme/components/CustomHome.vue - Fixed language detection and added Japanese translations                                                                                                         
                                                                                            