### PR TITLE
fix: improve image visibility in dark mode

### DIFF
--- a/book/online-book/src/10-minimum-example/040-minimum-virtual-dom.md
+++ b/book/online-book/src/10-minimum-example/040-minimum-virtual-dom.md
@@ -193,7 +193,11 @@ Therefore, the patch function is divided into two processes: "initial (generatin
 These processes are named "mount" and "patch" respectively. \
 And they are performed separately for ElementNode and TextNode (combined as "process" with the name "mount" and "patch" for each).
 
-![patch_fn_architecture](https://raw.githubusercontent.com/chibivue-land/chibivue/main/book/images/patch_fn_architecture.drawio.png)
+<img   
+    src="https://raw.githubusercontent.com/chibivue-land/chibivue/main/book/images/patch_fn_architecture.drawio.png"   
+    alt="Patch Function Architecture"   
+    style="background-color: white;"
+/>
 
 ```ts
 const patch = (


### PR DESCRIPTION

darkmodeで以下の章の画像が透過されて見にくいため`bg: white`を設定しました

https://book.chibivue.land/10-minimum-example/040-minimum-virtual-dom.html#design-of-the-patch-function

それか元画像の背景を設定すればfixします
他画像もざっと見ましたがこの画像だけのようです

before

<img width="785" height="637" alt="スクリーンショット 2026-01-21 14 45 27" src="https://github.com/user-attachments/assets/ebda2fa6-a30a-4a14-ba5e-d2a906dc9746" />

after

<img width="766" height="633" alt="スクリーンショット 2026-01-21 14 45 54" src="https://github.com/user-attachments/assets/f399e40e-7b69-4f35-bf82-f4dacca90c54" />
