### PR TITLE
fix: add white background to patch_fn_architecture image for all lang…

### DIFF
--- a/book/online-book/src/ja/10-minimum-example/040-minimum-virtual-dom.md
+++ b/book/online-book/src/ja/10-minimum-example/040-minimum-virtual-dom.md
@@ -204,7 +204,11 @@ patch 関数でやりたいことは 2 つの vnode の比較なので，便宜�
 そしてそれらは ElementNode と TextNode それぞれで行うようにします．\
 それぞれの mount と patch を process と言う名前でまとめてます．
 
-![patch_fn_architecture](https://raw.githubusercontent.com/chibivue-land/chibivue/main/book/images/patch_fn_architecture.drawio.png)
+<img   
+    src="https://raw.githubusercontent.com/chibivue-land/chibivue/main/book/images/patch_fn_architecture.drawio.png"   
+    alt="Patch Function Architecture"   
+    style="background-color: white;"
+/>
 
 ```ts
 const patch = (

--- a/book/online-book/src/zh-cn/10-minimum-example/040-minimum-virtual-dom.md
+++ b/book/online-book/src/zh-cn/10-minimum-example/040-minimum-virtual-dom.md
@@ -193,7 +193,11 @@ patch 函数比较两个 vnodes，vnode1 和 vnode2．但是，vnode1 最初不�
 这些过程分别命名为"mount"和"patch"．\
 它们分别对 ElementNode 和 TextNode 执行（结合为"process"，每个都有"mount"和"patch"名称）．
 
-![patch_fn_architecture](https://raw.githubusercontent.com/chibivue-land/chibivue/main/book/images/patch_fn_architecture.drawio.png)
+<img   
+    src="https://raw.githubusercontent.com/chibivue-land/chibivue/main/book/images/patch_fn_architecture.drawio.png"   
+    alt="Patch Function Architecture"   
+    style="background-color: white;"
+/>
 
 ```ts
 const patch = (

--- a/book/online-book/src/zh-tw/10-minimum-example/040-minimum-virtual-dom.md
+++ b/book/online-book/src/zh-tw/10-minimum-example/040-minimum-virtual-dom.md
@@ -185,7 +185,11 @@ patch 函數比較兩個 vnodes，vnode1 和 vnode2．但是，vnode1 最初不�
 這些過程分別命名為「mount」和「patch」．\
 它們分別對 ElementNode 和 TextNode 執行（結合為「process」，每個都有「mount」和「patch」名稱）．
 
-![patch_fn_architecture](https://raw.githubusercontent.com/chibivue-land/chibivue/main/book/images/patch_fn_architecture.drawio.png)
+<img   
+    src="https://raw.githubusercontent.com/chibivue-land/chibivue/main/book/images/patch_fn_architecture.drawio.png"   
+    alt="Patch Function Architecture"   
+    style="background-color: white;"
+/>
 
 ```ts
 const patch = (


### PR DESCRIPTION
#628 
Regarding the issue of images with transparent backgrounds making them difficult to see, the English version of the page has been fixed, but three pages in Japanese and Chinese (Simplified and Traditional) remained unfixed, so the remaining pages have also been fixed.

# Before
<img width="1039" height="855" alt="clip_20260125_160002" src="https://github.com/user-attachments/assets/6c9447b4-5abe-4c71-8716-7d807403998e" />

# After
<img width="1034" height="864" alt="clip_20260125_160025" src="https://github.com/user-attachments/assets/b1d5a127-2f56-4a1d-9486-4d60bc49a2f8" />

# Before
<img width="1103" height="828" alt="clip_20260125_155840" src="https://github.com/user-attachments/assets/44eed7a5-7626-4b3a-8ccd-3a8094f58539" />

# After
<img width="1070" height="820" alt="clip_20260125_155912" src="https://github.com/user-attachments/assets/a6f54c58-a0f0-4685-8530-44f65ddf2198" />

# Before
<img width="1042" height="820" alt="clip_20260125_155736" src="https://github.com/user-attachments/assets/8bca2e19-5568-4b24-b114-8990c3b33ec3" />

# After
<img width="1053" height="823" alt="clip_20260125_155810" src="https://github.com/user-attachments/assets/c9deda54-284f-4ebe-bca1-d55b0508aa22" />
