### PR TITLE
fix: 🐛 typo in "key属性とパッチレンダリング"

### DIFF
--- a/book/online-book/src/ja/20-basic-virtual-dom/010-patch-keyed-children.md
+++ b/book/online-book/src/ja/20-basic-virtual-dom/010-patch-keyed-children.md
@@ -90,7 +90,7 @@ https://ja.vuejs.org/api/built-in-special-attributes.html#key
 
 ## key 属性を元に patch しよう
 
-そしてこれらを実装しているのが，``という関数です．(本家 Vue で探してみましょう．)
+そしてこれらを実装しているのが，`patchKeyedChildren`という関数です．(本家 Vue で探してみましょう．)
 
 方針としては，まず新しい node の key と index のマップを生成します．
 


### PR DESCRIPTION
## Summary
@ubugeeei 
日本語ドキュメントのみ、 patchKeyedChildren 関数の指定が消えていたため修正しました。

<img width="1264" height="263" alt="image" src="https://github.com/user-attachments/assets/64617b60-5bf4-4864-9382-8980d5366423" />


https://book.chibivue.land/ja/20-basic-virtual-dom/010-patch-keyed-children.html#key-%E5%B1%9E%E6%80%A7%E3%82%92%E5%85%83%E3%81%AB-patch-%E3%81%97%E3%82%88%E3%81%86