### PR TITLE
fix: typo in English setup project chapter heading

### DIFF
--- a/book/online-book/src/00-introduction/040-setup-project.md
+++ b/book/online-book/src/00-introduction/040-setup-project.md
@@ -162,7 +162,7 @@ Contents of packages/index.ts
 console.log("Hello, World")
 ```
 
-### ### Building the Playground Side
+### Building the Playground Side
 
 ```sh
 pwd # ~/


### PR DESCRIPTION
@ubugeeei

Fixed a duplicate heading in the English setup project chapter.

`### ### Building the Playground Side` → `### Building the Playground Side`

This typo only exists in the English version. JA / ZH-CN / ZH-TW already use a single heading, so no other locales were changed.

Page: https://book.chibivue.land/00-introduction/040-setup-project.html#building-the-playground-side