### PR TITLE
docs: restore missing compiler-dom steps in template compiler chapter

### DIFF
--- a/book/online-book/src/10-minimum-example/061-template-compiler-impl.md
+++ b/book/online-book/src/10-minimum-example/061-template-compiler-impl.md
@@ -238,6 +238,27 @@ https://github.com/vuejs/core/blob/main/.github/contributing.md#package-dependen
 ## Continued Implementation
 
 We've jumped ahead a bit, but let's continue with the implementation. \
+Considering the discussion just now, what we're implementing is a compiler that runs at runtime, so creating `compiler-dom` next is a good fit.
+
+```sh
+pwd # ~/
+mkdir packages/compiler-dom
+touch packages/compiler-dom/index.ts
+```
+
+We'll implement it in `packages/compiler-dom/index.ts`.
+
+```ts
+import { baseCompile } from '../compiler-core'
+
+export function compile(template: string) {
+  return baseCompile(template)
+}
+```
+
+You might be thinking: "Wait... so this is just codegen? Then how do we generate the function?" \
+In fact, we still don't generate the function here. The actual function generation happens in packages/index.ts. (In the official Vue source, that would be packages/vue/src/index.ts.)
+
 Although I would like to implement `packages/index.ts`, there is some preparation work to be done, so let's do that first. \
 The preparation work is to implement a variable in `packages/runtime-core/component.ts` to hold the compiler itself, and a registration function.
 
@@ -292,7 +313,7 @@ export type ComponentOptions = {
 }
 ```
 
-Now, let's compile the important part.
+Now we get to the key part — compilation — but first we need to do a small refactor of the renderer.
 
 ```ts
 const mountComponent = (initialVNode: VNode, container: RendererElement) => {
@@ -378,7 +399,7 @@ app.mount('#app')
 ![Simple template compiler output before cleanup](/figures/10-minimum-example/template-compiler-impl/simple-template-compiler-before.png)
 
 It seems to be working fine. \
-Let's try making some changes to see if they are reflected.
+Templates with the same structure should all be compilable, so let's tweak it a bit and confirm that the change takes effect.
 
 ```ts
 const app = createApp({

--- a/book/online-book/src/10-minimum-example/061-template-compiler-impl.md
+++ b/book/online-book/src/10-minimum-example/061-template-compiler-impl.md
@@ -257,7 +257,7 @@ export function compile(template: string) {
 ```
 
 You might be thinking: "Wait... so this is just codegen? Then how do we generate the function?" \
-In fact, we still don't generate the function here. The actual function generation happens in packages/index.ts. (In the official Vue source, that would be packages/vue/src/index.ts.)
+In fact, we still don't generate the function here. The actual function generation happens in `packages/index.ts`. (In the official Vue source, that would be [packages/vue/src/index.ts](https://github.com/vuejs/core/blob/main/packages/vue/src/index.ts).)
 
 Although I would like to implement `packages/index.ts`, there is some preparation work to be done, so let's do that first. \
 The preparation work is to implement a variable in `packages/runtime-core/component.ts` to hold the compiler itself, and a registration function.

--- a/book/online-book/src/zh-cn/10-minimum-example/061-template-compiler-impl.md
+++ b/book/online-book/src/zh-cn/10-minimum-example/061-template-compiler-impl.md
@@ -257,7 +257,7 @@ export function compile(template: string) {
 ```
 
 你可能会想："诶？？这样不就只是进行了 codegen 吗？那函数的生成要怎么办？"\
-实际上，这里也没有进行函数生成。真正生成函数的地方是在 packages/index.ts。（对应 Vue 官方源码的话，就是 packages/vue/src/index.ts。）
+实际上，这里也没有进行函数生成。真正生成函数的地方是在 `packages/index.ts`。（对应 Vue 官方源码的话，就是 [packages/vue/src/index.ts](https://github.com/vuejs/core/blob/main/packages/vue/src/index.ts)。）
 
 虽然我想实现 `packages/index.ts`，但有一些准备工作要做，所以让我们先做那个．\
 准备工作是在 `packages/runtime-core/component.ts` 中实现一个变量来保存编译器本身，以及一个注册函数．

--- a/book/online-book/src/zh-cn/10-minimum-example/061-template-compiler-impl.md
+++ b/book/online-book/src/zh-cn/10-minimum-example/061-template-compiler-impl.md
@@ -237,9 +237,30 @@ https://github.com/vuejs/core/blob/main/.github/contributing.md#package-dependen
 
 ## 继续实现
 
-我们跳得有点快，但让我们继续实现。\
-虽然我想实现 `packages/index.ts`，但有一些准备工作要做，所以让我们先做那个。\
-准备工作是在 `packages/runtime-core/component.ts` 中实现一个变量来保存编译器本身，以及一个注册函数。
+我们跳得有点快，但让我们继续实现．\
+考虑到刚才的讨论，我们现在正在实现的是一个运行时中运行的编译器，因此接下来创建 `compiler-dom` 会比较合适。
+
+```sh
+pwd # ~/
+mkdir packages/compiler-dom
+touch packages/compiler-dom/index.ts
+```
+
+在 `packages/compiler-dom/index.ts` 中实现．
+
+```ts
+import { baseCompile } from '../compiler-core'
+
+export function compile(template: string) {
+  return baseCompile(template)
+}
+```
+
+你可能会想："诶？？这样不就只是进行了 codegen 吗？那函数的生成要怎么办？"\
+实际上，这里也没有进行函数生成。真正生成函数的地方是在 packages/index.ts。（对应 Vue 官方源码的话，就是 packages/vue/src/index.ts。）
+
+虽然我想实现 `packages/index.ts`，但有一些准备工作要做，所以让我们先做那个．\
+准备工作是在 `packages/runtime-core/component.ts` 中实现一个变量来保存编译器本身，以及一个注册函数．
 
 `packages/runtime-core/component.ts`
 
@@ -292,7 +313,7 @@ export type ComponentOptions = {
 }
 ```
 
-现在，让我们编译重要部分。
+现在进入关键的编译部分，不过我们需要先对 renderer 做一些小的重构。
 
 ```ts
 const mountComponent = (initialVNode: VNode, container: RendererElement) => {
@@ -377,8 +398,8 @@ app.mount('#app')
 
 ![Simple template compiler output before cleanup](/figures/10-minimum-example/template-compiler-impl/simple-template-compiler-before.png)
 
-看起来工作正常。\
-让我们尝试做一些更改，看看它们是否得到反映。
+看起来工作正常．\
+由于相同结构的模板应该都可以被编译，我们稍微修改一下，确认修改是否能够生效。
 
 ```ts
 const app = createApp({

--- a/book/online-book/src/zh-tw/10-minimum-example/061-template-compiler-impl.md
+++ b/book/online-book/src/zh-tw/10-minimum-example/061-template-compiler-impl.md
@@ -237,9 +237,30 @@ https://github.com/vuejs/core/blob/main/.github/contributing.md#package-dependen
 
 ## 繼續實作
 
-我們跳得有點快，但讓我們繼續實作。\
-雖然我想實作 `packages/index.ts`，但有一些準備工作要做，所以讓我們先做那個。\
-準備工作是在 `packages/runtime-core/component.ts` 中實作一個變數來儲存編譯器本身，以及一個註冊函式。
+我們跳得有點快，但讓我們繼續實現．\
+考慮到剛才的討論，我們現在正在實現的是一個執行時中執行的編譯器，因此接下來創建 `compiler-dom` 會比較合適．
+
+```sh
+pwd # ~/
+mkdir packages/compiler-dom
+touch packages/compiler-dom/index.ts
+```
+
+在 `packages/compiler-dom/index.ts` 中實現．
+
+```ts
+import { baseCompile } from '../compiler-core'
+
+export function compile(template: string) {
+  return baseCompile(template)
+}
+```
+
+你可能會想："欸？？這樣不就只是進行了 codegen 嗎？那函式的生成要怎麼辦？"\
+實際上，這裡也沒有進行函式生成．真正生成函式的地方是在 packages/index.ts．（對應 Vue 官方原始碼的話，就是 packages/vue/src/index.ts．）
+
+雖然我想實現 `packages/index.ts`，但有一些準備工作要做，所以讓我們先做那個．\
+準備工作是在 `packages/runtime-core/component.ts` 中實現一個變數來保存編譯器本身，以及一個註冊函式．
 
 `packages/runtime-core/component.ts`
 
@@ -292,7 +313,7 @@ export type ComponentOptions = {
 }
 ```
 
-現在，讓我們編譯重要部分。
+現在進入關鍵的編譯部分，不過我們需要先對 renderer 做一些小的重構．
 
 ```ts
 const mountComponent = (initialVNode: VNode, container: RendererElement) => {
@@ -377,8 +398,8 @@ app.mount('#app')
 
 ![Simple template compiler output before cleanup](/figures/10-minimum-example/template-compiler-impl/simple-template-compiler-before.png)
 
-看起來工作正常。\
-讓我們嘗試做一些更改，看看它們是否得到反映。
+看起來工作正常．\
+由於相同結構的模板應該都可以被編譯，我們稍微修改一下，確認修改是否能夠生效．
 
 ```ts
 const app = createApp({

--- a/book/online-book/src/zh-tw/10-minimum-example/061-template-compiler-impl.md
+++ b/book/online-book/src/zh-tw/10-minimum-example/061-template-compiler-impl.md
@@ -257,7 +257,7 @@ export function compile(template: string) {
 ```
 
 你可能會想："欸？？這樣不就只是進行了 codegen 嗎？那函式的生成要怎麼辦？"\
-實際上，這裡也沒有進行函式生成．真正生成函式的地方是在 packages/index.ts．（對應 Vue 官方原始碼的話，就是 packages/vue/src/index.ts．）
+實際上，這裡也沒有進行函式生成．真正生成函式的地方是在 `packages/index.ts`．（對應 Vue 官方原始碼的話，就是 [packages/vue/src/index.ts](https://github.com/vuejs/core/blob/main/packages/vue/src/index.ts)．）
 
 雖然我想實現 `packages/index.ts`，但有一些準備工作要做，所以讓我們先做那個．\
 準備工作是在 `packages/runtime-core/component.ts` 中實現一個變數來保存編譯器本身，以及一個註冊函式．


### PR DESCRIPTION
@ubugeeei

Compared with the [Japanese template compiler implementation chapter](https://book.chibivue.land/ja/10-minimum-example/061-template-compiler-impl.html#実装の続き), the EN / zh-CN / zh-TW docs are missing the `compiler-dom` setup and jumped straight to `packages/index.ts`, as well as other related content.

This PR fills that gap:

- Add the `compiler-dom` setup commands, the `compile()` wrapper, and the note that function generation happens in `packages/index.ts` (with the official Vue source link) ([L236–L258](https://github.com/chibivue-land/chibivue/blob/main/book/online-book/src/ja/10-minimum-example/061-template-compiler-impl.md?plain=1#L236-L258))
- Clarify the renderer refactor before compilation ([L314](https://github.com/chibivue-land/chibivue/blob/main/book/online-book/src/ja/10-minimum-example/061-template-compiler-impl.md?plain=1#L314))
- Clarify the follow-up playground tweak ([L398](https://github.com/chibivue-land/chibivue/blob/main/book/online-book/src/ja/10-minimum-example/061-template-compiler-impl.md?plain=1#L398))