### PR TITLE
docs: restore missing source and key docs links in patch-keyed-children translations

### DIFF
--- a/book/online-book/src/20-basic-virtual-dom/010-patch-keyed-children.md
+++ b/book/online-book/src/20-basic-virtual-dom/010-patch-keyed-children.md
@@ -84,7 +84,7 @@ Now, let's take a look at the explanation of the key attribute in the Vue docume
 
 > The special attribute key is primarily used as a hint for Vue's Virtual DOM algorithm to identify VNodes when diffing the new list of nodes against the old list.
 
-https://v3-migration.vuejs.org/breaking-changes/key-attribute.html
+https://vuejs.org/api/built-in-special-attributes.html#key
 
 As expected, right? You may have heard the advice "do not use index as the key for v-for", but at this point, the key is implicitly set to the index, which is why the above problems occur. (The loop is based on the length of c2, and patching is done based on that index)
 
@@ -120,7 +120,8 @@ In the original Vue, this `patchKeyedChildren` is divided into five parts:
 4. common sequence + unmount
 5. unknown sequence
 
-However, the last part, `unknown sequence`, is the only one that is functionally necessary, so we will start by reading and implementing that part.
+However, the first four are optimizations, so functionally it can work with just the `unknown sequence` part.
+So, let's start by reading through and implementing the `unknown sequence` part.
 
 First, forget about moving elements and patch VNodes based on the key.
 Using the `keyToNewIndexMap` we created earlier, calculate the pairs of n1 and n2 and patch them.
@@ -364,3 +365,6 @@ Now that we have explained the approach in detail, let's actually implement `pat
 5. Perform `move` based on the subsequence obtained in step 4 and `c2`.
 
 You can refer to the original Vue implementation or the chibivue implementation for guidance. (I recommend reading the original Vue implementation while following along.)
+
+Source code up to this point:
+[chibivue (GitHub)](https://github.com/chibivue-land/chibivue/tree/main/book/impls/20_basic_virtual_dom/010_patch_keyed_children)

--- a/book/online-book/src/zh-cn/20-basic-virtual-dom/010-patch-keyed-children.md
+++ b/book/online-book/src/zh-cn/20-basic-virtual-dom/010-patch-keyed-children.md
@@ -84,7 +84,7 @@ app.mount('#app')
 
 > 特殊属性 key 主要用作 Vue 虚拟DOM算法的提示，在比较新旧节点列表时识别 VNode。
 
-https://v3-migration.vuejs.org/breaking-changes/key-attribute.html
+https://cn.vuejs.org/api/built-in-special-attributes.html#key
 
 正如预期的那样，对吧？你可能听过"不要使用索引作为 v-for 的 key"的建议，但在这一点上，key 被隐式设置为索引，这就是为什么会出现上述问题。（循环基于 c2 的长度，并基于该索引进行补丁）
 
@@ -120,7 +120,8 @@ for (i = s2; i <= e2; i++) {
 4. common sequence + unmount
 5. unknown sequence
 
-然而，最后一部分 `unknown sequence` 是唯一在功能上必需的，所以我们将从阅读和实现该部分开始。
+然而，上面 4 个更像是优化，所以在功能上只靠最后的 `unknown sequence` 也能工作。
+因此，我们先阅读并实现 `unknown sequence` 这一部分。
 
 首先，忘记移动元素，基于 key 对 VNode 进行补丁。
 使用我们之前创建的 `keyToNewIndexMap`，计算 n1 和 n2 的配对并对它们进行补丁。
@@ -364,3 +365,6 @@ for (i = toBePatched - 1; i >= 0; i--) {
 5. 基于步骤 4 中获得的子序列和 `c2` 执行 `move`。
 
 你可以参考原始 Vue 实现或 chibivue 实现作为指导。（我建议在跟随的同时阅读原始 Vue 实现。）
+
+到此为止的源代码：
+[chibivue (GitHub)](https://github.com/chibivue-land/chibivue/tree/main/book/impls/20_basic_virtual_dom/010_patch_keyed_children)

--- a/book/online-book/src/zh-tw/20-basic-virtual-dom/010-patch-keyed-children.md
+++ b/book/online-book/src/zh-tw/20-basic-virtual-dom/010-patch-keyed-children.md
@@ -84,7 +84,7 @@ app.mount('#app')
 
 > 特殊屬性 key 主要用作 Vue 虛擬DOM演算法的提示，在比較新舊節點列表時識別 VNode。
 
-https://v3-migration.vuejs.org/breaking-changes/key-attribute.html
+https://zh-hk.vuejs.org/api/built-in-special-attributes.html#key
 
 正如預期的那樣，對吧？你可能聽過"不要使用索引作為 v-for 的 key"的建議，但在這一點上，key 被隱式設定為索引，這就是為什麼會出現上述問題。（循環基於 c2 的長度，並基於該索引進行補丁）
 
@@ -120,7 +120,8 @@ for (i = s2; i <= e2; i++) {
 4. common sequence + unmount
 5. unknown sequence
 
-然而，最後一部分 `unknown sequence` 是唯一在功能上必需的，所以我們將從閱讀和實作該部分開始。
+但是，上述四項比較像是最佳化，因此在功能上只靠最後的 `unknown sequence` 就能運作。
+所以，先從 `unknown sequence` 的部分開始閱讀並實作吧。
 
 首先，忘記移動元素，基於 key 對 VNode 進行補丁。
 使用我們之前建立的 `keyToNewIndexMap`，計算 n1 和 n2 的配對並對它們進行補丁。
@@ -364,3 +365,6 @@ for (i = toBePatched - 1; i >= 0; i--) {
 5. 基於步驟 4 中獲得的子序列和 `c2` 執行 `move`。
 
 你可以參考原始 Vue 實作或 chibivue 實作作為指導。（我建議在跟隨的同時閱讀原始 Vue 實作。）
+
+到此為止的原始碼：
+[chibivue (GitHub)](https://github.com/chibivue-land/chibivue/tree/main/book/impls/20_basic_virtual_dom/010_patch_keyed_children)


### PR DESCRIPTION
@ubugeeei

Compared with the [Japanese patch keyed children chapter](https://book.chibivue.land/ja/20-basic-virtual-dom/010-patch-keyed-children.html), the EN / zh-CN / zh-TW docs are missing the chapter-end chibivue source link, and the `key` docs link goes to the Vue 3 migration guide instead of the built-in special attributes page, as well as other related content.

This PR aligns those locales with the Japanese source:

- Correct the Vue `key` docs URL to the built-in special attributes page ([L87](https://github.com/chibivue-land/chibivue/blob/main/book/online-book/src/ja/20-basic-virtual-dom/010-patch-keyed-children.md?plain=1#L87))
- Restore the note that the first four `patchKeyedChildren` parts are optimizations ([L123–L124](https://github.com/chibivue-land/chibivue/blob/main/book/online-book/src/ja/20-basic-virtual-dom/010-patch-keyed-children.md?plain=1#L123-L124))
- Restore the chapter-end chibivue source link ([L372–L373](https://github.com/chibivue-land/chibivue/blob/main/book/online-book/src/ja/20-basic-virtual-dom/010-patch-keyed-children.md?plain=1#L372-L373))


Made with [Cursor](https://cursor.com)